### PR TITLE
Feature/print context

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -11,7 +11,8 @@
 #' @param tweaks \code{[DBItest_tweaks]}\cr Tweaks as constructed by the
 #'   \code{\link{tweaks}} function.
 #' @param ctx \code{[DBItest_context]}\cr A test context.
-#' @param name An optional name of the context
+#' @param name \code{[character]}\cr An optional name of the context which will 
+#'   be used in test messages.
 #' @return \code{[DBItest_context]}\cr A test context, for
 #'   \code{set_default_context} the previous default context (invisibly) or
 #'   \code{NULL}.

--- a/R/context.R
+++ b/R/context.R
@@ -11,6 +11,7 @@
 #' @param tweaks \code{[DBItest_tweaks]}\cr Tweaks as constructed by the
 #'   \code{\link{tweaks}} function.
 #' @param ctx \code{[DBItest_context]}\cr A test context.
+#' @param name An optional name of the context
 #' @return \code{[DBItest_context]}\cr A test context, for
 #'   \code{set_default_context} the previous default context (invisibly) or
 #'   \code{NULL}.
@@ -18,7 +19,7 @@
 #' @rdname context
 #' @export
 make_context <- function(drv, connect_args, set_as_default = TRUE,
-                         tweaks = NULL) {
+                         tweaks = NULL, name = NULL) {
   drv_call <- substitute(drv)
 
   if (is.null(drv)) {
@@ -34,7 +35,8 @@ make_context <- function(drv, connect_args, set_as_default = TRUE,
       drv = drv,
       drv_call = drv_call,
       connect_args = connect_args,
-      tweaks = tweaks
+      tweaks = tweaks,
+      name = name
     ),
     class = "DBItest_context"
   )

--- a/R/run.R
+++ b/R/run.R
@@ -1,6 +1,6 @@
 run_tests <- function(tests, skip, test_suite, ctx_name) {
   test_context <- paste0(
-    "DBItest", ifelse(is.null(ctx_name), "", paste0("[", ctx_name, "]")),
+    "DBItest", if(!is.null(ctx_name)) paste0("[", ctx_name, "]"),
     ": ", test_suite)
   context(test_context)
 

--- a/R/run.R
+++ b/R/run.R
@@ -1,13 +1,15 @@
 run_tests <- function(tests, skip, test_suite, ctx_name) {
-  text_context <- paste0("DBItest", ifelse(is.null(ctx_name), "", paste0("[", ctx_name, "]")))
-  context(paste0(text_context, ": ", test_suite))
+  test_context <- paste0(
+    "DBItest", ifelse(is.null(ctx_name), "", paste0("[", ctx_name, "]")),
+    ": ", test_suite)
+  context(test_context)
 
   tests <- tests[!vapply(tests, is.null, logical(1L))]
 
   skip_rx <- paste0(paste0("(?:^", skip, "$)"), collapse = "|")
 
   vapply(names(tests), function(test_name) {
-    ok <- test_that(paste0(text_context, ": ", test_name), {
+    ok <- test_that(paste0(test_context, ": ", test_name), {
       if (grepl(skip_rx, test_name, perl = TRUE)) {
         skip("by request")
       } else {

--- a/R/run.R
+++ b/R/run.R
@@ -1,12 +1,13 @@
-run_tests <- function(tests, skip, test_suite) {
-  context(paste("DBItest:", test_suite))
+run_tests <- function(tests, skip, test_suite, ctx_name) {
+  text_context <- paste0("DBItest", ifelse(is.null(ctx_name), "", paste0("[", ctx_name, "]")))
+  context(paste0(text_context, ": ", test_suite))
 
   tests <- tests[!vapply(tests, is.null, logical(1L))]
 
   skip_rx <- paste0(paste0("(?:^", skip, "$)"), collapse = "|")
 
   vapply(names(tests), function(test_name) {
-    ok <- test_that(paste0("DBItest: ", test_name), {
+    ok <- test_that(paste0(text_context, ": ", test_name), {
       if (grepl(skip_rx, test_name, perl = TRUE)) {
         skip("by request")
       } else {

--- a/R/test_compliance.R
+++ b/R/test_compliance.R
@@ -48,7 +48,7 @@ test_compliance <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }
 
 #' @importFrom methods hasMethod

--- a/R/test_connection.R
+++ b/R/test_connection.R
@@ -123,5 +123,5 @@ test_connection <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }

--- a/R/test_driver.R
+++ b/R/test_driver.R
@@ -142,5 +142,5 @@ test_driver <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }

--- a/R/test_getting_started.R
+++ b/R/test_getting_started.R
@@ -24,8 +24,7 @@ test_getting_started <- function(skip = NULL, ctx = get_default_context()) {
     #' \code{make_context()} must be called before calling any of the
     #' \code{test_} functions in this package}
     has_context = function() {
-      object <- ctx # object duplication fixes lazyeval error
-      expect_is(object, "DBItest_context")
+      expect_is((ctx), "DBItest_context")
     },
 
     #' \item{\code{package_dependencies}}{

--- a/R/test_getting_started.R
+++ b/R/test_getting_started.R
@@ -50,7 +50,7 @@ test_getting_started <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }
 
 get_pkg <- function(ctx) {

--- a/R/test_getting_started.R
+++ b/R/test_getting_started.R
@@ -24,8 +24,8 @@ test_getting_started <- function(skip = NULL, ctx = get_default_context()) {
     #' \code{make_context()} must be called before calling any of the
     #' \code{test_} functions in this package}
     has_context = function() {
-      expected_ctx <- ctx
-      expect_is(expected_ctx, "DBItest_context")
+      object <- ctx # object duplication fixes lazyeval error
+      expect_is(object, "DBItest_context")
     },
 
     #' \item{\code{package_dependencies}}{

--- a/R/test_getting_started.R
+++ b/R/test_getting_started.R
@@ -24,7 +24,8 @@ test_getting_started <- function(skip = NULL, ctx = get_default_context()) {
     #' \code{make_context()} must be called before calling any of the
     #' \code{test_} functions in this package}
     has_context = function() {
-      expect_is(ctx, "DBItest_context")
+      expected_ctx <- ctx
+      expect_is(expected_ctx, "DBItest_context")
     },
 
     #' \item{\code{package_dependencies}}{

--- a/R/test_meta.R
+++ b/R/test_meta.R
@@ -879,7 +879,7 @@ test_meta <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }
 
 test_select_bind <- function(con, placeholder_fun, values,

--- a/R/test_result.R
+++ b/R/test_result.R
@@ -945,7 +945,7 @@ test_result <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #'}
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }
 
 utils::globalVariables("con")

--- a/R/test_sql.R
+++ b/R/test_sql.R
@@ -587,7 +587,7 @@ test_sql <- function(skip = NULL, ctx = get_default_context()) {
     NULL
   )
   #' }
-  run_tests(tests, skip, test_suite)
+  run_tests(tests, skip, test_suite, ctx$name)
 }
 
 get_iris <- function(ctx) {

--- a/man/context.Rd
+++ b/man/context.Rd
@@ -6,7 +6,8 @@
 \alias{set_default_context}
 \title{Test contexts}
 \usage{
-make_context(drv, connect_args, set_as_default = TRUE, tweaks = NULL)
+make_context(drv, connect_args, set_as_default = TRUE, tweaks = NULL,
+  name = NULL)
 
 set_default_context(ctx)
 
@@ -24,6 +25,9 @@ set as default context?}
 
 \item{tweaks}{\code{[DBItest_tweaks]}\cr Tweaks as constructed by the
 \code{\link{tweaks}} function.}
+
+\item{name}{\code{[character]}\cr An optional name of the context which will 
+be used in test messages.}
 
 \item{ctx}{\code{[DBItest_context]}\cr A test context.}
 }


### PR DESCRIPTION
Adds the possibility to give a DBItest_context a name which will be used test messages.

Example:
```R
DBItest::make_context(..., name = NULL) # default
# BItest: Getting started: ....S

DBItest::make_context(..., name = "read_only")
# BItest[read_only]: Getting started: ....S
```
