### PR TITLE
Explicitly cast data tests to precise types

### DIFF
--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -13,7 +13,7 @@ spec_result_roundtrip <- list(
   #' Data conversion from SQL to R: integer with typed NULL values.
   data_integer_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1 AS integer)" = 1L, "CAST(-100 AS integer)" = -100L, .add_null = "below")
+      test_select(.ctx = ctx, con, "CAST(1 AS int)" = 1L, "CAST(-100 AS int)" = -100L, .add_null = "below")
     })
   },
 
@@ -21,21 +21,21 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_integer_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1 AS integer)" = 1L, "CAST(-100 AS integer)" = -100L, .add_null = "above")
+      test_select(.ctx = ctx, con, "CAST(1 AS int)" = 1L, "CAST(-100 AS int)" = -100L, .add_null = "above")
     })
   },
 
   #' Data conversion from SQL to R: numeric.
   data_numeric = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5)
+      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5)
     })
   },
 
   #' Data conversion from SQL to R: numeric with typed NULL values.
   data_numeric_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5, .add_null = "below")
+      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5, .add_null = "below")
     })
   },
 
@@ -43,7 +43,7 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_numeric_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5, .add_null = "above")
+      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5, .add_null = "above")
     })
   },
 

--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -13,7 +13,7 @@ spec_result_roundtrip <- list(
   #' Data conversion from SQL to R: integer with typed NULL values.
   data_integer_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, 1L, -100L, .add_null = "below")
+      test_select(.ctx = ctx, con, "CAST(1 AS integer)" = 1L, "CAST(-100 AS integer)" = -100L, .add_null = "below")
     })
   },
 
@@ -21,21 +21,21 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_integer_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, 1L, -100L, .add_null = "above")
+      test_select(.ctx = ctx, con, "CAST(1 AS integer)" = 1L, "CAST(-100 AS integer)" = -100L, .add_null = "above")
     })
   },
 
   #' Data conversion from SQL to R: numeric.
   data_numeric = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, 1.5, -100.5)
+      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5)
     })
   },
 
   #' Data conversion from SQL to R: numeric with typed NULL values.
   data_numeric_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, 1.5, -100.5, .add_null = "below")
+      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5, .add_null = "below")
     })
   },
 
@@ -43,7 +43,7 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_numeric_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, 1.5, -100.5, .add_null = "above")
+      test_select(.ctx = ctx, con, "CAST(1.5 AS real)" = 1.5, "CAST(-100.5 AS real)" = -100.5, .add_null = "above")
     })
   },
 

--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -13,7 +13,7 @@ spec_result_roundtrip <- list(
   #' Data conversion from SQL to R: integer with typed NULL values.
   data_integer_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1 AS int)" = 1L, "CAST(-100 AS int)" = -100L, .add_null = "below")
+      test_select(.ctx = ctx, con, "integer '1'" = 1L, "integer '-100'" = -100L, .add_null = "below")
     })
   },
 
@@ -21,21 +21,21 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_integer_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1 AS int)" = 1L, "CAST(-100 AS int)" = -100L, .add_null = "above")
+      test_select(.ctx = ctx, con, "integer '1'" = 1L, "integer '-100'" = -100L, .add_null = "above")
     })
   },
 
   #' Data conversion from SQL to R: numeric.
   data_numeric = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5)
+      test_select(.ctx = ctx, con, "real '1.5'" = 1.5, "real '-100.5'" = -100.5)
     })
   },
 
   #' Data conversion from SQL to R: numeric with typed NULL values.
   data_numeric_null_below = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5, .add_null = "below")
+      test_select(.ctx = ctx, con, "real '1.5'" = 1.5, "real '-100.5'" = -100.5, .add_null = "below")
     })
   },
 
@@ -43,7 +43,7 @@ spec_result_roundtrip <- list(
   #' in the first row.
   data_numeric_null_above = function(ctx) {
     with_connection({
-      test_select(.ctx = ctx, con, "CAST(1.5 AS float(18))" = 1.5, "CAST(-100.5 AS float(18))" = -100.5, .add_null = "above")
+      test_select(.ctx = ctx, con, "real '1.5'" = 1.5, "real '-100.5'" = -100.5, .add_null = "above")
     })
   },
 


### PR DESCRIPTION
Previously the real number tests for being implicitly casted to SQL
exact numeric types, which can have precision exceeding R numeric types.
For this reason they were being converted to strings, which was causing
the tests to fail.

This change explicit defines them to be real types, which can be
exactly converted to R numeric types.

The issue was only manifesting itself with the floating point values, but I added casts for the integers to be complete.