### PR TITLE
Dates should be numeric internally, not integers

### DIFF
--- a/R/spec-result-roundtrip.R
+++ b/R/spec-result-roundtrip.R
@@ -234,19 +234,19 @@ spec_result_roundtrip <- list(
   data_date = function(ctx) {
     with_connection({
       test_select(.ctx = ctx, con,
-                  "date('2015-01-01')" = as_integer_date("2015-01-01"),
-                  "date('2015-02-02')" = as_integer_date("2015-02-02"),
-                  "date('2015-03-03')" = as_integer_date("2015-03-03"),
-                  "date('2015-04-04')" = as_integer_date("2015-04-04"),
-                  "date('2015-05-05')" = as_integer_date("2015-05-05"),
-                  "date('2015-06-06')" = as_integer_date("2015-06-06"),
-                  "date('2015-07-07')" = as_integer_date("2015-07-07"),
-                  "date('2015-08-08')" = as_integer_date("2015-08-08"),
-                  "date('2015-09-09')" = as_integer_date("2015-09-09"),
-                  "date('2015-10-10')" = as_integer_date("2015-10-10"),
-                  "date('2015-11-11')" = as_integer_date("2015-11-11"),
-                  "date('2015-12-12')" = as_integer_date("2015-12-12"),
-                  "current_date" ~ as_integer_date(Sys.time()))
+                  "date('2015-01-01')" = as_numeric_date("2015-01-01"),
+                  "date('2015-02-02')" = as_numeric_date("2015-02-02"),
+                  "date('2015-03-03')" = as_numeric_date("2015-03-03"),
+                  "date('2015-04-04')" = as_numeric_date("2015-04-04"),
+                  "date('2015-05-05')" = as_numeric_date("2015-05-05"),
+                  "date('2015-06-06')" = as_numeric_date("2015-06-06"),
+                  "date('2015-07-07')" = as_numeric_date("2015-07-07"),
+                  "date('2015-08-08')" = as_numeric_date("2015-08-08"),
+                  "date('2015-09-09')" = as_numeric_date("2015-09-09"),
+                  "date('2015-10-10')" = as_numeric_date("2015-10-10"),
+                  "date('2015-11-11')" = as_numeric_date("2015-11-11"),
+                  "date('2015-12-12')" = as_numeric_date("2015-12-12"),
+                  "current_date" ~ as_numeric_date(Sys.time()))
     })
   },
 
@@ -254,19 +254,19 @@ spec_result_roundtrip <- list(
   data_date_null_below = function(ctx) {
     with_connection({
       test_select(.ctx = ctx, con,
-                  "date('2015-01-01')" = as_integer_date("2015-01-01"),
-                  "date('2015-02-02')" = as_integer_date("2015-02-02"),
-                  "date('2015-03-03')" = as_integer_date("2015-03-03"),
-                  "date('2015-04-04')" = as_integer_date("2015-04-04"),
-                  "date('2015-05-05')" = as_integer_date("2015-05-05"),
-                  "date('2015-06-06')" = as_integer_date("2015-06-06"),
-                  "date('2015-07-07')" = as_integer_date("2015-07-07"),
-                  "date('2015-08-08')" = as_integer_date("2015-08-08"),
-                  "date('2015-09-09')" = as_integer_date("2015-09-09"),
-                  "date('2015-10-10')" = as_integer_date("2015-10-10"),
-                  "date('2015-11-11')" = as_integer_date("2015-11-11"),
-                  "date('2015-12-12')" = as_integer_date("2015-12-12"),
-                  "current_date" ~ as_integer_date(Sys.time()),
+                  "date('2015-01-01')" = as_numeric_date("2015-01-01"),
+                  "date('2015-02-02')" = as_numeric_date("2015-02-02"),
+                  "date('2015-03-03')" = as_numeric_date("2015-03-03"),
+                  "date('2015-04-04')" = as_numeric_date("2015-04-04"),
+                  "date('2015-05-05')" = as_numeric_date("2015-05-05"),
+                  "date('2015-06-06')" = as_numeric_date("2015-06-06"),
+                  "date('2015-07-07')" = as_numeric_date("2015-07-07"),
+                  "date('2015-08-08')" = as_numeric_date("2015-08-08"),
+                  "date('2015-09-09')" = as_numeric_date("2015-09-09"),
+                  "date('2015-10-10')" = as_numeric_date("2015-10-10"),
+                  "date('2015-11-11')" = as_numeric_date("2015-11-11"),
+                  "date('2015-12-12')" = as_numeric_date("2015-12-12"),
+                  "current_date" ~ as_numeric_date(Sys.time()),
                   .add_null = "below")
     })
   },
@@ -276,19 +276,19 @@ spec_result_roundtrip <- list(
   data_date_null_above = function(ctx) {
     with_connection({
       test_select(.ctx = ctx, con,
-                  "date('2015-01-01')" = as_integer_date("2015-01-01"),
-                  "date('2015-02-02')" = as_integer_date("2015-02-02"),
-                  "date('2015-03-03')" = as_integer_date("2015-03-03"),
-                  "date('2015-04-04')" = as_integer_date("2015-04-04"),
-                  "date('2015-05-05')" = as_integer_date("2015-05-05"),
-                  "date('2015-06-06')" = as_integer_date("2015-06-06"),
-                  "date('2015-07-07')" = as_integer_date("2015-07-07"),
-                  "date('2015-08-08')" = as_integer_date("2015-08-08"),
-                  "date('2015-09-09')" = as_integer_date("2015-09-09"),
-                  "date('2015-10-10')" = as_integer_date("2015-10-10"),
-                  "date('2015-11-11')" = as_integer_date("2015-11-11"),
-                  "date('2015-12-12')" = as_integer_date("2015-12-12"),
-                  "current_date" ~ as_integer_date(Sys.time()),
+                  "date('2015-01-01')" = as_numeric_date("2015-01-01"),
+                  "date('2015-02-02')" = as_numeric_date("2015-02-02"),
+                  "date('2015-03-03')" = as_numeric_date("2015-03-03"),
+                  "date('2015-04-04')" = as_numeric_date("2015-04-04"),
+                  "date('2015-05-05')" = as_numeric_date("2015-05-05"),
+                  "date('2015-06-06')" = as_numeric_date("2015-06-06"),
+                  "date('2015-07-07')" = as_numeric_date("2015-07-07"),
+                  "date('2015-08-08')" = as_numeric_date("2015-08-08"),
+                  "date('2015-09-09')" = as_numeric_date("2015-09-09"),
+                  "date('2015-10-10')" = as_numeric_date("2015-10-10"),
+                  "date('2015-11-11')" = as_numeric_date("2015-11-11"),
+                  "date('2015-12-12')" = as_numeric_date("2015-12-12"),
+                  "current_date" ~ as_numeric_date(Sys.time()),
                   .add_null = "above")
     })
   },
@@ -594,7 +594,7 @@ is_roughly_current_time <- function(x) {
   is_time(x) && (Sys.time() - x <= 2)
 }
 
-as_integer_date <- function(d) {
+as_numeric_date <- function(d) {
   d <- as.Date(d)
-  structure(as.integer(unclass(d)), class = class(d))
+  structure(as.numeric(unclass(d)), class = class(d))
 }

--- a/R/spec-sql-read-write-roundtrip.R
+++ b/R/spec-sql-read-write-roundtrip.R
@@ -201,7 +201,7 @@ spec_sql_read_write_roundtrip <- list(
 
       tbl_out <- dbReadTable(con, "test")
       expect_equal(tbl_in, tbl_out[order(tbl_out$id), ])
-      expect_is(unclass(tbl_out$a), "integer")
+      expect_is(unclass(tbl_out$a), "numeric")
     })
   },
 


### PR DESCRIPTION
This is consistent with base R dates, which are always constructed as numerics

``` r
str(unclass(as.Date("2016-01-01")))
#>  num 16801
str(unclass(Sys.Date()))
#>  num 17107
```

This is true of [base::as.Date.default](https://github.com/wch/r-source/blob/45b3b3d6256b7c4cf94834b00f187388d523b25b/src/library/base/R/dates.R#L73) and the other coercion methods in that file.  Also output as numeric in [readr](https://github.com/tidyverse/readr/blob/37d6eda5b2e52707bfa6ea2db8d52e0209796615/src/Collector.h#L101).

If there are cases in base R where Dates are constructed as integers it seems like they are the exception rather than the rule and are likely bugs.

@hadley mentioned he was previously confused on this issue.

Associated issues, https://github.com/hadley/dplyr/issues/1303, https://github.com/rstats-db/RMySQL/issues/86#issuecomment-151783522, https://github.com/rstats-db/DBItest/issues/9