### PR TITLE
fix roundtrip timestamp

### DIFF
--- a/R/spec-sql-read-write-roundtrip.R
+++ b/R/spec-sql-read-write-roundtrip.R
@@ -211,13 +211,12 @@ spec_sql_read_write_roundtrip <- list(
       tbl_in <- data.frame(id = 1:5)
       tbl_in$a <- round(Sys.time()) + c(1, 60, 3600, 86400, NA)
       tbl_in$b <- as.POSIXlt(tbl_in$a, tz = "GMT")
-      tbl_in$c <- as.POSIXlt(tbl_in$a, tz = "PST")
+      tbl_in$c <- as.POSIXlt(tbl_in$a, tz = "PST8PDT")
 
       on.exit(expect_error(dbRemoveTable(con, "test"), NA), add = TRUE)
       dbWriteTable(con, "test", tbl_in)
-
       tbl_out <- dbReadTable(con, "test")
-      expect_identical(tbl_in, tbl_out[order(tbl_out$id), ])
+      expect_equivalent(tbl_in, tbl_out[order(tbl_out$id), ])
     })
   },
 


### PR DESCRIPTION
This fixes two small issues with timestamp comparisons.
 
First PST is not a time zone. R accepts it without error but effectively uses UTC instead. See this R session: I am currently in the Paris timezone. If I use PST8PDT which is a proper timezone,  it shows 9 hours behind as it should.

```
> test <- Sys.time()
> test
[1] "2016-12-29 10:24:31 CET"
> as.POSIXlt(test, "PST")
[1] "2016-12-29 09:24:31 PST"
> as.POSIXlt(,test, "PST8PDT")
[1] ""2016-12-29 01:24:31 PST"
```
Second when comparing timestamps, I think we need to use equivalent instead of equal, because two timestamps with the same epoch but different timestamps would be different objects.