### PR TITLE
Check only the values returned from roundtrip_time

### DIFF
--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -489,9 +489,10 @@ spec_sql_write_table <- list(
         dbWriteTable(con, "test", tbl_in)
 
         tbl_out <- dbReadTable(con, "test")
-        expect_equal_df(tbl_out, tbl_in)
+
         #'   returned as objects that inherit from `difftime`)
         expect_is(tbl_out$a, "difftime")
+        expect_identical(unclass(tbl_out$a), unclass(tbl_in$a))
       })
     })
   },

--- a/R/spec-sql-write-table.R
+++ b/R/spec-sql-write-table.R
@@ -492,7 +492,7 @@ spec_sql_write_table <- list(
 
         #'   returned as objects that inherit from `difftime`)
         expect_is(tbl_out$a, "difftime")
-        expect_identical(unclass(tbl_out$a), unclass(tbl_in$a))
+        expect_identical(hms::as.hms(tbl_out$a), hms::as.hms(tbl_in$a))
       })
     })
   },


### PR DESCRIPTION
This allows backends to return a hms object if desired.

Fixes #134